### PR TITLE
feat!: Easier result type

### DIFF
--- a/do.go
+++ b/do.go
@@ -5,7 +5,7 @@ import (
 )
 
 // DoAll is the shorthand of Parallel and Task.Do.
-func DoAll[T any, E comparable](ctx context.Context, tasks ...Task[Result[T, E]]) Result[[]T, E] {
+func DoAll[T any](ctx context.Context, tasks ...Task[Result[T]]) Result[[]T] {
 	return Parallel(tasks...).Do(ctx)
 }
 
@@ -20,7 +20,7 @@ func DoRace[T any](ctx context.Context, tasks ...Task[T]) T {
 }
 
 // DoAllFns is the shorthand of TasksFrom + Parallel + Task.Do.
-func DoAllFns[T any, E comparable](ctx context.Context, fns ...func(context.Context) Result[T, E]) Result[[]T, E] {
+func DoAllFns[T any, E comparable](ctx context.Context, fns ...func(context.Context) Result[T]) Result[[]T] {
 	return DoAll(ctx, TasksFrom(fns...)...)
 }
 

--- a/parallel.go
+++ b/parallel.go
@@ -7,9 +7,9 @@ import (
 // Parallel creates a task that runs the children in parallel, and returns all values resolved by each child task.
 // On any task returned an error, the remaining tasks will be canceled immediately and returns the error.
 // This is only compatible with tasks that returns Result.
-func Parallel[T any, E comparable](tasks ...Task[Result[T, E]]) Task[Result[[]T, E]] {
-	return NewTask(func(ctx context.Context) Result[[]T, E] {
-		resultChan := make(chan Result[T, E])
+func Parallel[T any](tasks ...Task[Result[T]]) Task[Result[[]T]] {
+	return NewTask(func(ctx context.Context) Result[[]T] {
+		resultChan := make(chan Result[T])
 
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
@@ -22,7 +22,7 @@ func Parallel[T any, E comparable](tasks ...Task[Result[T, E]]) Task[Result[[]T,
 		for {
 			result := <-resultChan
 			if result.IsErr() {
-				return ResultErr[[]T, E](result.UnwrapErr())
+				return ResultErr[[]T](result.UnwrapErr())
 			}
 
 			values = append(values, result.Unwrap())
@@ -31,7 +31,7 @@ func Parallel[T any, E comparable](tasks ...Task[Result[T, E]]) Task[Result[[]T,
 			}
 		}
 
-		return ResultOk[[]T, E](values)
+		return ResultOk[[]T](values)
 	})
 }
 

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -11,15 +11,15 @@ import (
 
 func TestParallel(t *testing.T) {
 	task := Parallel(
-		NewTask(func(ctx context.Context) Result[string, error] {
+		NewTask(func(ctx context.Context) Result[string] {
 			time.Sleep(900 * time.Millisecond)
 
-			return ResultOk[string, error]("The first task is resolved!")
+			return ResultOk("The first task is resolved!")
 		}),
-		NewTask(func(ctx context.Context) Result[string, error] {
+		NewTask(func(ctx context.Context) Result[string] {
 			time.Sleep(1000 * time.Millisecond)
 
-			return ResultOk[string, error]("The second task is resolved!")
+			return ResultOk("The second task is resolved!")
 		}),
 	)
 
@@ -37,15 +37,15 @@ func TestParallel(t *testing.T) {
 
 func TestParallel_Error(t *testing.T) {
 	task := Parallel(
-		NewTask(func(ctx context.Context) Result[string, error] {
+		NewTask(func(ctx context.Context) Result[string] {
 			time.Sleep(900 * time.Millisecond)
 
-			return ResultOk[string, error]("The first task is resolved!")
+			return ResultOk("The first task is resolved!")
 		}),
-		NewTask(func(ctx context.Context) Result[string, error] {
+		NewTask(func(ctx context.Context) Result[string] {
 			time.Sleep(1000 * time.Millisecond)
 
-			return ResultErr[string, error](errors.New("the second task occurred an error"))
+			return ResultErr[string](errors.New("the second task occurred an error"))
 		}),
 	)
 
@@ -58,20 +58,20 @@ func TestParallel_Error(t *testing.T) {
 
 func TestParallelSettled(t *testing.T) {
 	task := ParallelSettled(
-		NewTask(func(ctx context.Context) Result[string, error] {
+		NewTask(func(ctx context.Context) Result[string] {
 			time.Sleep(800 * time.Millisecond)
 
-			return ResultOk[string, error]("The first task is resolved!")
+			return ResultOk("The first task is resolved!")
 		}),
-		NewTask(func(ctx context.Context) Result[string, error] {
+		NewTask(func(ctx context.Context) Result[string] {
 			time.Sleep(900 * time.Millisecond)
 
-			return ResultErr[string, error](errors.New("the second task occurred an error"))
+			return ResultErr[string](errors.New("the second task occurred an error"))
 		}),
-		NewTask(func(ctx context.Context) Result[string, error] {
+		NewTask(func(ctx context.Context) Result[string] {
 			time.Sleep(1000 * time.Millisecond)
 
-			return ResultOk[string, error]("The third task is resolved!")
+			return ResultOk("The third task is resolved!")
 		}),
 	)
 
@@ -81,9 +81,9 @@ func TestParallelSettled(t *testing.T) {
 	finishedAt := time.Now()
 
 	assert.True(t, finishedAt.Sub(startedAt) < 1100*time.Millisecond)
-	assert.Equal(t, []Result[string, error]{
-		ResultOk[string, error]("The first task is resolved!"),
-		ResultErr[string, error](errors.New("the second task occurred an error")),
-		ResultOk[string, error]("The third task is resolved!"),
+	assert.Equal(t, []Result[string]{
+		ResultOk("The first task is resolved!"),
+		ResultErr[string](errors.New("the second task occurred an error")),
+		ResultOk("The third task is resolved!"),
 	}, actual)
 }

--- a/race_test.go
+++ b/race_test.go
@@ -10,15 +10,15 @@ import (
 
 func TestRace(t *testing.T) {
 	task := Race(
-		NewTask(func(ctx context.Context) Result[string, error] {
+		NewTask(func(ctx context.Context) Result[string] {
 			time.Sleep(1000 * time.Millisecond)
 
-			return ResultOk[string, error]("The first task is resolved!")
+			return ResultOk("The first task is resolved!")
 		}),
-		NewTask(func(ctx context.Context) Result[string, error] {
+		NewTask(func(ctx context.Context) Result[string] {
 			time.Sleep(500 * time.Millisecond)
 
-			return ResultOk[string, error]("The second task is resolved!")
+			return ResultOk("The second task is resolved!")
 		}),
 	)
 

--- a/result.go
+++ b/result.go
@@ -1,32 +1,32 @@
 package gotask
 
-type Result[T any, E comparable] struct {
+type Result[T any] struct {
 	ok  T
-	err E
+	err error
 }
 
-func NewResult[T any, E comparable](ok T, err E) Result[T, E] {
-	return Result[T, E]{
+func NewResult[T any](ok T, err error) Result[T] {
+	return Result[T]{
 		ok:  ok,
 		err: err,
 	}
 }
 
-func ResultOk[T any, E comparable](ok T) Result[T, E] {
-	return Result[T, E]{
+func ResultOk[T any](ok T) Result[T] {
+	return Result[T]{
 		ok: ok,
 	}
 }
 
-func ResultErr[T any, E comparable](err E) Result[T, E] {
-	return Result[T, E]{
+func ResultErr[T any](err error) Result[T] {
+	return Result[T]{
 		err: err,
 	}
 }
 
-func UnwrapMany[T any, E comparable](results ...Result[T, E]) ([]T, []E) {
+func UnwrapMany[T any](results ...Result[T]) ([]T, []error) {
 	values := make([]T, 0, len(results))
-	errs := make([]E, 0, len(results))
+	errs := make([]error, 0, len(results))
 	for _, result := range results {
 		if result.IsOk() {
 			values = append(values, result.Unwrap())
@@ -38,15 +38,15 @@ func UnwrapMany[T any, E comparable](results ...Result[T, E]) ([]T, []E) {
 	return values, errs
 }
 
-func (r Result[T, E]) IsOk() bool {
+func (r Result[T]) IsOk() bool {
 	return isZero(r.err)
 }
 
-func (r Result[T, E]) IsErr() bool {
+func (r Result[T]) IsErr() bool {
 	return !isZero(r.err)
 }
 
-func (r Result[T, E]) Unwrap() T {
+func (r Result[T]) Unwrap() T {
 	if r.IsErr() {
 		panic("an error result was unwrapped as ok")
 	}
@@ -54,7 +54,7 @@ func (r Result[T, E]) Unwrap() T {
 	return r.ok
 }
 
-func (r Result[T, E]) UnwrapErr() E {
+func (r Result[T]) UnwrapErr() error {
 	if r.IsOk() {
 		panic("an ok result was unwrapped as error")
 	}
@@ -62,6 +62,6 @@ func (r Result[T, E]) UnwrapErr() E {
 	return r.err
 }
 
-func (r Result[T, E]) AsTuple() (T, E) {
+func (r Result[T]) AsTuple() (T, error) {
 	return r.ok, r.err
 }

--- a/result_test.go
+++ b/result_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestUnwrapMany(t *testing.T) {
 	values, errs := UnwrapMany(
-		ResultOk[string, error]("abc"),
-		ResultErr[string, error](errors.New("error occurred (1)")),
-		ResultOk[string, error]("def"),
-		ResultErr[string, error](errors.New("error occurred (2)")),
-		ResultOk[string, error]("ghi"),
+		ResultOk("abc"),
+		ResultErr[string](errors.New("error occurred (1)")),
+		ResultOk("def"),
+		ResultErr[string](errors.New("error occurred (2)")),
+		ResultOk("ghi"),
 	)
 
 	assert.Len(t, values, 3)

--- a/then.go
+++ b/then.go
@@ -5,14 +5,14 @@ import (
 )
 
 // Then creates a new task that runs two tasks serially.
-func Then[T, U any, E comparable](
-	task Task[Result[T, E]],
-	fn func(context.Context, T) Result[U, E],
-) Task[Result[U, E]] {
-	return NewTask(func(ctx context.Context) Result[U, E] {
+func Then[T, U any](
+	task Task[Result[T]],
+	fn func(context.Context, T) Result[U],
+) Task[Result[U]] {
+	return NewTask(func(ctx context.Context) Result[U] {
 		result := task.Do(ctx)
 		if result.IsErr() {
-			return ResultErr[U, E](result.UnwrapErr())
+			return ResultErr[U](result.UnwrapErr())
 		}
 
 		return fn(ctx, result.Unwrap())
@@ -20,9 +20,9 @@ func Then[T, U any, E comparable](
 }
 
 // Catch creates a new task that fallbacks to onError behaviour on the task returned an error.
-func Catch[T any, E comparable](
-	task Task[Result[T, E]],
-	onError func(context.Context, E) T,
+func Catch[T any](
+	task Task[Result[T]],
+	onError func(context.Context, error) T,
 ) Task[T] {
 	return NewTask(func(ctx context.Context) T {
 		result := task.Do(ctx)

--- a/then_test.go
+++ b/then_test.go
@@ -12,10 +12,10 @@ import (
 
 func TestThen(t *testing.T) {
 	task := Then(
-		NewTask(func(ctx context.Context) Result[string, error] {
-			return ResultOk[string, error]("123")
+		NewTask(func(ctx context.Context) Result[string] {
+			return ResultOk("123")
 		}),
-		func(ctx context.Context, value string) Result[int, error] {
+		func(ctx context.Context, value string) Result[int] {
 			return NewResult(strconv.Atoi(value))
 		},
 	)
@@ -27,8 +27,8 @@ func TestThen(t *testing.T) {
 
 func TestCatch(t *testing.T) {
 	task := Catch(
-		NewTask(func(ctx context.Context) Result[string, error] {
-			return ResultErr[string, error](errors.New("error occurred"))
+		NewTask(func(ctx context.Context) Result[string] {
+			return ResultErr[string](errors.New("error occurred"))
 		}),
 		func(ctx context.Context, err error) string {
 			return fmt.Sprintf("ERROR: %s", err.Error())


### PR DESCRIPTION
BREAKING CHANGE: Now `E` of `gotask.Result[T, E]` is always `error`. Technically, the `E` type variable has been removed.